### PR TITLE
Add missing returns to prevent compiler warns.

### DIFF
--- a/src/optiga_trustm/pal_gpio_arduino.cpp
+++ b/src/optiga_trustm/pal_gpio_arduino.cpp
@@ -60,9 +60,10 @@ LIBRARY_EXPORTS pal_status_t pal_gpio_init(const pal_gpio_t * p_gpio_context)
     {
         pinMode(*(uint8_t*)p_gpio_context->p_gpio_hw, OUTPUT);
     }
+    return PAL_STATUS_SUCCESS;
 }
 
 LIBRARY_EXPORTS pal_status_t pal_gpio_deinit(const pal_gpio_t * p_gpio_context)
 {
-    
+    return PAL_STATUS_SUCCESS;
 }

--- a/src/optiga_trustm/pal_logger_arduino.cpp
+++ b/src/optiga_trustm/pal_logger_arduino.cpp
@@ -49,11 +49,12 @@ pal_logger_t logger_console =
 pal_status_t pal_logger_init(void * p_logger_context)
 {
     //Initialized in arduino setup()
+    return PAL_STATUS_SUCCESS;
 }
 
 pal_status_t pal_logger_deinit(void * p_logger_context)
 {
-    
+    return PAL_STATUS_SUCCESS;
 }
 
 pal_status_t pal_logger_write(void * p_logger_context, const uint8_t * p_log_data, uint32_t log_data_length)
@@ -63,9 +64,10 @@ pal_status_t pal_logger_write(void * p_logger_context, const uint8_t * p_log_dat
   for(int i=0; i< log_data_length; i++) {
     Serial.print(str.charAt(i));
   }
+  return PAL_STATUS_SUCCESS;
 }
 
 pal_status_t pal_logger_read(void * p_logger_context, uint8_t * p_log_data, uint32_t log_data_length)
 {
-
+  return PAL_STATUS_SUCCESS;
 }


### PR DESCRIPTION
There are several functions that are prototyped to have returns, but then do not actually return the expected parameter. This is generally a warn, but some cores may set this to flag as an error and prevent compilation. The Raspberry Pi RP2040 for example:
https://github.com/earlephilhower/arduino-pico/blob/52b31204489ebe1ac3628cdb7ce3d5db7153d940/platform.txt#L35-L39

Compiling the `getRandom.ino` example for a target board of Raspberry Pi Pico leads to:
```
/home/user/Arduino/libraries/arduino-optiga-trust-m/src/optiga_trustm/pal_gpio_arduino.cpp: In function 'pal_status_t pal_gpio_init(const pal_gpio_t*)':
/home/user/Arduino/libraries/arduino-optiga-trust-m/src/optiga_trustm/pal_gpio_arduino.cpp:63:1: error: no return statement in function returning non-void [-Werror=return-type]
   63 | }
      | ^
/home/user/Arduino/libraries/arduino-optiga-trust-m/src/optiga_trustm/pal_gpio_arduino.cpp: In function 'pal_status_t pal_gpio_deinit(const pal_gpio_t*)':
/home/user/Arduino/libraries/arduino-optiga-trust-m/src/optiga_trustm/pal_gpio_arduino.cpp:68:1: error: no return statement in function returning non-void [-Werror=return-type]
   68 | }
      | ^
cc1plus: some warnings being treated as errors
/home/user/.arduino15/packages/rp2040/tools/pqt-gcc/1.3.1-a-7855b0c/bin/arm-none-eabi-g++ -c -Werror=return-type -I/home/user/.arduino15/packages/rp2040/hardware/rp2040/1.9.6/tools/libpico -DCFG_TUSB_MCU=OPT_MCU_RP2040 -DUSB_VID=0x2e8a -DUSB_PID=0x000a "-DUSB_MANUFACTURER=\"Raspberry Pi\"" "-DUSB_PRODUCT=\"Pico\"" -march=armv6-m -mcpu=cortex-m0plus -mthumb -ffunction-sections -fdata-sections -fno-exceptions -iprefix/home/user/.arduino15/packages/rp2040/hardware/rp2040/1.9.6/ @/home/user/.arduino15/packages/rp2040/hardware/rp2040/1.9.6/lib/platform_inc.txt -fno-rtti -std=gnu++17 -g -DSERIALUSB_PID=0x000a -DF_CPU=125000000L -DARDUINO=10816 -DARDUINO_RASPBERRY_PI_PICO "-DBOARD_NAME=\"RASPBERRY_PI_PICO\"" -DARDUINO_ARCH_RP2040 -Os -I/home/user/.arduino15/packages/rp2040/hardware/rp2040/1.9.6/cores/rp2040 -I/home/user/.arduino15/packages/rp2040/hardware/rp2040/1.9.6/variants/rpipico -I/home/user/Arduino/libraries/arduino-optiga-trust-m/src -I/home/user/.arduino15/packages/rp2040/hardware/rp2040/1.9.6/libraries/Wire/src /home/user/Arduino/libraries/arduino-optiga-trust-m/src/optiga_trustm/pal_os_datastore_arduino.cpp -o /tmp/arduino_build_391361/libraries/arduino-optiga-trust-m/optiga_trustm/pal_os_datastore_arduino.cpp.o
/home/user/Arduino/libraries/arduino-optiga-trust-m/src/optiga_trustm/pal_logger_arduino.cpp: In function 'pal_status_t pal_logger_init(void*)':
/home/user/Arduino/libraries/arduino-optiga-trust-m/src/optiga_trustm/pal_logger_arduino.cpp:52:1: error: no return statement in function returning non-void [-Werror=return-type]
   52 | }
      | ^
/home/user/Arduino/libraries/arduino-optiga-trust-m/src/optiga_trustm/pal_logger_arduino.cpp: In function 'pal_status_t pal_logger_deinit(void*)':
/home/user/Arduino/libraries/arduino-optiga-trust-m/src/optiga_trustm/pal_logger_arduino.cpp:57:1: error: no return statement in function returning non-void [-Werror=return-type]
   57 | }
      | ^
/home/user/Arduino/libraries/arduino-optiga-trust-m/src/optiga_trustm/pal_logger_arduino.cpp: In function 'pal_status_t pal_logger_write(void*, const uint8_t*, uint32_t)':
/home/user/Arduino/libraries/arduino-optiga-trust-m/src/optiga_trustm/pal_logger_arduino.cpp:66:1: error: no return statement in function returning non-void [-Werror=return-type]
   66 | }
      | ^
/home/user/Arduino/libraries/arduino-optiga-trust-m/src/optiga_trustm/pal_logger_arduino.cpp: In function 'pal_status_t pal_logger_read(void*, uint8_t*, uint32_t)':
/home/user/Arduino/libraries/arduino-optiga-trust-m/src/optiga_trustm/pal_logger_arduino.cpp:71:1: error: no return statement in function returning non-void [-Werror=return-type]
   71 | }
      | ^
cc1plus: some warnings being treated as errors
Using library arduino-optiga-trust-m at version 1.1.0 in folder: /home/user/Arduino/libraries/arduino-optiga-trust-m 
Using library Wire at version 1.0 in folder: /home/user/.arduino15/packages/rp2040/hardware/rp2040/1.9.6/libraries/Wire 
exit status 1
Error compiling for board Raspberry Pi Pico.
```

This PR simply adds returns of `PAL_STATUS_SUCCESS` to fix this.